### PR TITLE
Fix BLE race conditions

### DIFF
--- a/hal/src/duo/btstack_hal.c
+++ b/hal/src/duo/btstack_hal.c
@@ -543,9 +543,11 @@ void hal_btstack_deInit(void)
     {
         hci_init_flag = 0;
         have_custom_addr = false;
-        hci_close();
-        btstack_run_loop_deInit();
         hal_btstack_thread_quit = 1;
+	wiced_rtos_thread_join(&hal_btstack_thread_);
+        btstack_run_loop_deInit();
+	hci_power_control(HCI_POWER_OFF);
+        hci_close();
     }
 }
 


### PR DESCRIPTION
Fix race condition with queued BLE notifications/indications being silently discarded because previous notification/indication was not confirmed by the GATT client yet. Also, fix a startup race condition where hci_init_flag was set after the Bluetooth stack thread was spawned and occasionally caused the thread to quit immediately.